### PR TITLE
Fix ProgressBar.progressBar is not a constructor

### DIFF
--- a/src/extras/index.js
+++ b/src/extras/index.js
@@ -11,7 +11,7 @@ if (!window.oc.AjaxExtras) {
     // Namespace
     window.oc.AjaxExtras = namespace;
     window.oc.flashMsg = FlashMessage.flashMsg;
-    window.oc.progressBar = new ProgressBar.progressBar();
+    window.oc.progressBar = ProgressBar.progressBar();
 }
 
 // Boot controller


### PR DESCRIPTION
![Снимок экрана 2022-06-16 в 10 35 54](https://user-images.githubusercontent.com/20070837/174017778-cfb3d4ac-edbf-4d54-8b6c-e14ad96ab41b.png)
![Снимок экрана 2022-06-16 в 10 36 48](https://user-images.githubusercontent.com/20070837/174017809-ee71e450-e157-4bf8-856e-eb701a60785b.png)

Removing 'new' fixes the error.