### PR TITLE
Fixed emptyMode check

### DIFF
--- a/src/extras/validator.js
+++ b/src/extras/validator.js
@@ -33,7 +33,7 @@ export class Validator
             // Display message next to field
             var field = form.querySelector('[data-validate-for="'+fieldName+'"]');
             if (field) {
-                if (!field.innerHTML || field.dataset.emptyMode === true) {
+                if (!field.innerHTML || field.dataset.emptyMode) {
                     field.dataset.emptyMode = true;
                     field.innerHTML = fieldMessages.join(', ');
                 }


### PR DESCRIPTION
I have noticed that validation messages are only updated once. Subsequent validation errors are not displayed correctly.
This PR fixed a strict comparision error which is the culprit of this issue.